### PR TITLE
Using single scope per test improves performance

### DIFF
--- a/tests/Application.IntegrationTests/TestBase.cs
+++ b/tests/Application.IntegrationTests/TestBase.cs
@@ -1,16 +1,55 @@
-﻿using NUnit.Framework;
+﻿using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
 using System.Threading.Tasks;
 
 namespace CleanTesting.Application.IntegrationTests
 {
     using static Testing;
 
+    [TestFixture]
     public class TestBase
     {
+        protected IServiceScope Scope { get; private set; }
+
         [SetUp]
         public async Task SetUp()
         {
             await ResetState();
+
+            this.Scope = CreateScope();
+        }
+
+        [TearDown]
+        public void BaseTearDown() 
+        {
+            if (Scope != null)
+            {
+                Scope.Dispose();
+                Scope = null;
+            }
+        }
+
+        protected virtual async Task<TEntity> FindAsync<TEntity>(int id)
+            where TEntity : class
+        {
+            return await Testing.FindAsync<TEntity>(id, Scope);
+        }
+
+        protected virtual async Task AddAsync<TEntity>(TEntity entity)
+            where TEntity : class
+        {
+            await Testing.AddAsync<TEntity>(entity, Scope);
+        }
+
+        protected virtual async Task<TResponse> SendAsync<TResponse>(IRequest<TResponse> request)
+        {
+            return await Testing.SendAsync<TResponse>(request, Scope);
+        }
+
+        protected virtual async Task<string> RunAsDefaultUserAsync()
+        {
+            return await Testing.RunAsDefaultUserAsync(Scope);
         }
     }
 }

--- a/tests/Application.IntegrationTests/TodoItems/Commands/CreateTodoItemTests.cs
+++ b/tests/Application.IntegrationTests/TodoItems/Commands/CreateTodoItemTests.cs
@@ -9,8 +9,6 @@ using System.Threading.Tasks;
 
 namespace CleanTesting.Application.IntegrationTests.TodoItems.Commands
 {
-    using static Testing;
-
     public class CreateTodoItemTests : TestBase
     {
         [Test]

--- a/tests/Application.IntegrationTests/TodoItems/Commands/DeleteTodoItemTests.cs
+++ b/tests/Application.IntegrationTests/TodoItems/Commands/DeleteTodoItemTests.cs
@@ -9,8 +9,6 @@ using NUnit.Framework;
 
 namespace CleanTesting.Application.IntegrationTests.TodoItems.Commands
 {
-    using static Testing;
-
     public class DeleteTodoItemTests : TestBase
     {
         [Test]

--- a/tests/Application.IntegrationTests/TodoItems/Commands/UpdateTodoItemDetailTests.cs
+++ b/tests/Application.IntegrationTests/TodoItems/Commands/UpdateTodoItemDetailTests.cs
@@ -12,8 +12,6 @@ using System;
 
 namespace CleanTesting.Application.IntegrationTests.TodoItems.Commands
 {
-    using static Testing;
-
     public class UpdateTodoItemDetailTests : TestBase
     {
         [Test]

--- a/tests/Application.IntegrationTests/TodoItems/Commands/UpdateTodoItemTests.cs
+++ b/tests/Application.IntegrationTests/TodoItems/Commands/UpdateTodoItemTests.cs
@@ -10,8 +10,6 @@ using System;
 
 namespace CleanTesting.Application.IntegrationTests.TodoItems.Commands
 {
-    using static Testing;
-
     public class UpdateTodoItemTests : TestBase
     {
         [Test]

--- a/tests/Application.IntegrationTests/TodoLists/Commands/CreateTodoListTests.cs
+++ b/tests/Application.IntegrationTests/TodoLists/Commands/CreateTodoListTests.cs
@@ -8,8 +8,6 @@ using System.Threading.Tasks;
 
 namespace CleanTesting.Application.IntegrationTests.TodoLists.Commands
 {
-    using static Testing;
-
     public class CreateTodoListTests : TestBase
     {
         [Test]

--- a/tests/Application.IntegrationTests/TodoLists/Commands/DeleteTodoListTests.cs
+++ b/tests/Application.IntegrationTests/TodoLists/Commands/DeleteTodoListTests.cs
@@ -8,8 +8,6 @@ using System.Threading.Tasks;
 
 namespace CleanTesting.Application.IntegrationTests.TodoLists.Commands
 {
-    using static Testing;
-
     public class DeleteTodoListTests : TestBase
     {
         [Test]

--- a/tests/Application.IntegrationTests/TodoLists/Commands/UpdateTodoListTests.cs
+++ b/tests/Application.IntegrationTests/TodoLists/Commands/UpdateTodoListTests.cs
@@ -9,8 +9,6 @@ using System.Threading.Tasks;
 
 namespace CleanTesting.Application.IntegrationTests.TodoLists.Commands
 {
-    using static Testing;
-
     public class UpdateTodoListTests : TestBase
     {
         [Test]

--- a/tests/Application.IntegrationTests/TodoLists/Queries/GetTodosTests.cs
+++ b/tests/Application.IntegrationTests/TodoLists/Queries/GetTodosTests.cs
@@ -7,8 +7,6 @@ using System.Threading.Tasks;
 
 namespace CleanTesting.Application.IntegrationTests.TodoLists.Queries
 {
-    using static Testing;
-
     public class GetTodosTests : TestBase
     {
         [Test]


### PR DESCRIPTION
It was taking about 4.5 -6 seconds for all test to execute using the original implementation.

Using single scope per test improved this timing a lot and it was 1.3 - 1.7sec for all tests